### PR TITLE
Show profile for guests

### DIFF
--- a/components/Auth/Auth.tsx
+++ b/components/Auth/Auth.tsx
@@ -22,6 +22,7 @@ const AuthClient = () => {
           <LoginForm
             setOpen={redirectToMainPage}
             handleAuthTypeChange={handleAuthTypeChange}
+            callbackUrl="/home"
           />
         ) : (
           <RegisterForm handleAuthTypeChange={handleAuthTypeChange} />

--- a/components/Buttons/ProfileButton.tsx
+++ b/components/Buttons/ProfileButton.tsx
@@ -2,45 +2,15 @@
 
 import { User } from "lucide-react";
 import { Button } from "../ui/button";
-import { useSession } from "next-auth/react";
-import { useState } from "react";
-import AuthModal from "../Modals/authModal/authModal";
 import Link from "next/link";
 
-interface Props {
-  text: string;
-  user?: boolean;
-}
-
-const ProfileButton = ({ text }: Props) => {
-  const [openModal, setOpenModal] = useState<boolean>(false);
-  const session = useSession();
-  const isAuthenticated = session.status === "authenticated" && session.data?.user?.id;
+const ProfileButton = () => {
   return (
-    <div>
-      {!isAuthenticated && (
-        <Button
-          onClick={() => setOpenModal(true)}
-          className="rounded-full bg-transparent border border-orange-500 text-orange-500 hover:bg-orange-500 hover:text-white"
-        >
-          <User /> {text}
-        </Button>
-      )}
-      {isAuthenticated && (
-        <Link href={`/profile`}>
-          <Button className="rounded-full bg-orange-100 border border-orange-200 text-orange-500 hover:bg-orange-500 hover:text-white">
-            <User /> Профиль
-          </Button>
-        </Link>
-      )}
-      {session.status === "loading" && (
-        <Button className="rounded-full bg-transparent border border-orange-500 text-orange-500 hover:bg-orange-500 hover:text-white">
-          Загружаем...
-        </Button>
-      )}
-
-      <AuthModal open={openModal} setOpen={setOpenModal} />
-    </div>
+    <Link href="/profile">
+      <Button className="rounded-full bg-orange-100 border border-orange-200 text-orange-500 hover:bg-orange-500 hover:text-white">
+        <User /> Профиль
+      </Button>
+    </Link>
   );
 };
 

--- a/components/Header/HeaderActions/HeaderActions.tsx
+++ b/components/Header/HeaderActions/HeaderActions.tsx
@@ -21,7 +21,7 @@ const HeaderActions = ({
           </Button>
         </Link>
       )}
-      <ProfileButton text="Войти" user={true} />
+      <ProfileButton />
 
       {hasCart && <ButtonCart />}
     </div>

--- a/components/Modals/authModal/authModal.tsx
+++ b/components/Modals/authModal/authModal.tsx
@@ -7,9 +7,10 @@ import Link from "next/link";
 interface Props {
   open: boolean;
   setOpen: (open: boolean) => void;
+  callbackUrl?: string;
 }
 
-const AuthModal = ({ open, setOpen }: Props) => {
+const AuthModal = ({ open, setOpen, callbackUrl }: Props) => {
   const [authType, setAuthType] = useState<"login" | "register">("login");
   const handleAuthTypeChange = () => {
     setAuthType((prevType) => (prevType === "login" ? "register" : "login"));
@@ -22,6 +23,7 @@ const AuthModal = ({ open, setOpen }: Props) => {
             <LoginForm
               setOpen={setOpen}
               handleAuthTypeChange={handleAuthTypeChange}
+              callbackUrl={callbackUrl}
             />
           )}
           {authType === "register" && (

--- a/components/Modals/authModal/login-form.tsx
+++ b/components/Modals/authModal/login-form.tsx
@@ -11,9 +11,10 @@ import { FcGoogle } from "react-icons/fc";
 interface Props {
   setOpen: (open: boolean) => void;
   handleAuthTypeChange: () => void;
+  callbackUrl?: string;
 }
 
-const LoginForm = ({ setOpen, handleAuthTypeChange }: Props) => {
+const LoginForm = ({ setOpen, handleAuthTypeChange, callbackUrl = "/home" }: Props) => {
   const form = useForm<TFormLoginValues>({
     resolver: zodResolver(formLoginSchema),
     defaultValues: {
@@ -27,7 +28,7 @@ const LoginForm = ({ setOpen, handleAuthTypeChange }: Props) => {
       const resp = await signIn("credentials", {
         ...data,
         redirect: false,
-        callbackUrl: "/home",
+        callbackUrl,
       });
 
       if (!resp?.ok) {
@@ -66,14 +67,14 @@ const LoginForm = ({ setOpen, handleAuthTypeChange }: Props) => {
         {/*Providers*/}
         <div className="flex gap-4 w-full">
           <Button
-            onClick={() => signIn("github", { callbackUrl: "/home" })}
+            onClick={() => signIn("github", { callbackUrl })}
             className="flex gap-2 flex-1 px-4 py-2 bg-black text-white rounded hover:bg-gray-800"
           >
             <IoLogoGithub />
             Войти с GitHub
           </Button>
           <Button
-            onClick={() => signIn("google", { callbackUrl: "/home" })}
+            onClick={() => signIn("google", { callbackUrl })}
             className="flex gap-2 flex-1 px-4 py-2 bg-white text-black rounded hover:bg-gray-100 border border-gray-100 "
           >
             <FcGoogle />

--- a/components/Profile/Profile.tsx
+++ b/components/Profile/Profile.tsx
@@ -12,6 +12,8 @@ import SignOutButton from "../Buttons/SignOutBtn";
 import toast from "react-hot-toast";
 import { signOut } from "next-auth/react";
 import ProfileForm from "./profile-form";
+import AuthModal from "../Modals/authModal/authModal";
+import { Button } from "../ui/button";
 
 export interface UserProfile {
   fullName: string;
@@ -27,6 +29,7 @@ interface Props {
 const ProfileClient = ({ data }: Props) => {
   const [user, setUser] = useState<UserProfile | null>(data);
   const [loading, setLoading] = useState(false);
+  const [openAuth, setOpenAuth] = useState(false);
 
   // Проверка пользователя при монтировании
   useEffect(() => {
@@ -120,6 +123,30 @@ const ProfileClient = ({ data }: Props) => {
     setLoading(false);
     toast.success("Профиль успешно обновлен!");
   };
+  if (!user) {
+    return (
+      <>
+        <div className="flex flex-col gap-4 mt-10" style={{ width: "400px" }}>
+          <p>
+            Вы не авторизованы. Войдите или зарегистрируйтесь, чтобы связать свои
+            заказы с аккаунтом.
+          </p>
+          <Button
+            onClick={() => setOpenAuth(true)}
+            className="bg-orange-500 text-white"
+          >
+            Войти или зарегистрироваться
+          </Button>
+        </div>
+        <AuthModal
+          open={openAuth}
+          setOpen={setOpenAuth}
+          callbackUrl="/profile"
+        />
+      </>
+    );
+  }
+
   return (
     <>
       <FormProvider {...form}>


### PR DESCRIPTION
## Summary
- simplify ProfileButton to always link to `/profile`
- update HeaderActions to use new ProfileButton
- add login modal handling inside guest profile
- extend AuthModal/LoginForm to accept a callbackUrl
- pass callback URL from Auth page

## Testing
- `npm run lint`
- `npm run build` *(fails: prisma binary download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68874088876083249a3e98b1ce4032aa