### PR TITLE
Preserve guest cart token on sign in

### DIFF
--- a/components/Modals/authModal/login-form.tsx
+++ b/components/Modals/authModal/login-form.tsx
@@ -31,6 +31,10 @@ const LoginForm = ({
     try {
       const resp = await signIn("credentials", {
         ...data,
+        cartToken:
+          typeof window !== "undefined"
+            ? localStorage.getItem("cartToken")
+            : undefined,
         redirect: false,
         callbackUrl,
       });

--- a/components/Modals/authModal/schema.ts
+++ b/components/Modals/authModal/schema.ts
@@ -12,12 +12,14 @@ export const formRegisterSchema = formLoginSchema
     z.object({
       fullName: z.string().min(2, { message: "Error FN" }),
       confirmPassword: passwordSchema,
-    })
+    }),
   )
   .refine((data) => data.password === data.confirmPassword, {
     message: "Пароли не совпадают",
     path: ["confirmPasswrod"],
   });
 
-export type TFormLoginValues = z.infer<typeof formLoginSchema>;
+export type TFormLoginValues = z.infer<typeof formLoginSchema> & {
+  cartToken?: string;
+};
 export type TFormRegisterValues = z.infer<typeof formRegisterSchema>;


### PR DESCRIPTION
## Summary
- update sign in callback to retrieve and re-set cart token

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688912f0c1e8832492ec4a23adad2703